### PR TITLE
monitor is not respecting waitfor priority

### DIFF
--- a/libcfa/src/concurrency/monitor.cfa
+++ b/libcfa/src/concurrency/monitor.cfa
@@ -930,40 +930,37 @@ static inline void brand_condition( condition & this ) {
 }
 
 static inline [thread$ *, int] search_entry_queue( const __waitfor_mask_t & mask, monitor$ * monitors [], __lock_size_t count ) {
-
 	__queue_t(thread$) & entry_queue = monitors[0]->entry_queue;
 
-	#if defined( __CFA_WITH_VERIFY__ )
-		thread$ * last = 0p;
-	#endif
-	// For each thread in the entry-queue
-	for(	thread$ ** thrd_it = &entry_queue.head;
-		(*thrd_it) != 1p;
-		thrd_it = &get_next(**thrd_it)
-	) {
-		thread$ * curr = *thrd_it;
+	int i = 0;
+	__acceptable_t * end   = end  (mask);
+	__acceptable_t * begin = begin(mask);
+    // For each acceptable (respect priority)
+    for( __acceptable_t * it = begin; it != end; it++, i++ ) {
+#if defined( __CFA_WITH_VERIFY__ )
+        thread$ * last = 0p;
+#endif // __CFA_WITH_VERIFY__
+        for(	thread$ ** thrd_it = &entry_queue.head;
+            (*thrd_it) != 1p;
+            thrd_it = &get_next(**thrd_it)
+        ) {
+            thread$ * curr = *thrd_it;
 
-		/* paranoid */ verifyf( !last || last->user_link.next == curr, "search not making progress, from %p (%p) to %p", last, last->user_link.next, curr );
-		/* paranoid */ verifyf( curr != last, "search not making progress, from %p to %p", last, curr );
+            /* paranoid */ verifyf( !last || last->user_link.next == curr, "search not making progress, from %p (%p) to %p", last, last->user_link.next, curr );
+            /* paranoid */ verifyf( curr != last, "search not making progress, from %p to %p", last, curr );
 
-		// For each acceptable check if it matches
-		int i = 0;
-		__acceptable_t * end   = end  (mask);
-		__acceptable_t * begin = begin(mask);
-		for( __acceptable_t * it = begin; it != end; it++, i++ ) {
-			// Check if we have a match
-			if( *it == curr->monitors ) {
+            // For each thread in the entry-queue check if we have a match
+            if( *it == curr->monitors ) {
+                // If we have a match return it
+                // after removeing it from the entry queue
+                return [remove( entry_queue, thrd_it ), i];
+            }
 
-				// If we have a match return it
-				// after removeing it from the entry queue
-				return [remove( entry_queue, thrd_it ), i];
-			}
-		}
-
-		#if defined( __CFA_WITH_VERIFY__ )
-			last = curr;
-		#endif
-	}
+            #if defined( __CFA_WITH_VERIFY__ )
+                last = curr;
+            #endif
+        }
+    }
 
 	return [0, -1];
 }


### PR DESCRIPTION
while working on cs343 assignment I realized that task/monitor waitfor priority is not working as expected.

I think the problem is caused by the way arrival queue is iterated over (should iterate over priority and then threads not the other way around).